### PR TITLE
File-level Violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ usage: imhotep [-h] [--config-file CONFIG_FILE] --repo_name REPO_NAME
                [--github-username GITHUB_USERNAME]
                [--github-password GITHUB_PASSWORD] [--no-post]
                [--authenticated] [--pr-number PR_NUMBER]
-               [--cache-directory CACHE_DIRECTORY]
+               [--cache-directory CACHE_DIRECTORY] [--report-file-violations]
 
 Posts static analysis results to github.
 
@@ -119,6 +119,9 @@ optional arguments:
                         Number of the pull request to comment on
   --cache-directory CACHE_DIRECTORY
                         Path to directory to cache the repository
+  --report-file-violations
+                        Report file-level violations, i.e. those not on
+                        individual lines
 ```
 
 Note: if you get a error where the plugin cannot find `imhotep.tools`, make

--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -61,7 +61,8 @@ class Imhotep(object):
                  repo_name=None, pr_number=None,
                  commit_info=None,
                  commit=None, origin_commit=None, no_post=None, debug=None,
-                 filenames=None, shallow_clone=False, **kwargs):
+                 filenames=None, shallow_clone=False,
+                 report_file_violations=False, **kwargs):
         # TODO(justinabrahms): kwargs exist until we handle cli params better
         # TODO(justinabrahms): This is a sprawling API. Tighten it up.
         self.requester = requester
@@ -78,6 +79,7 @@ class Imhotep(object):
             filenames = []
         self.requested_filenames = set(filenames)
         self.shallow = shallow_clone
+        self.report_file_violations = report_file_violations
 
         if self.commit is None and self.pr_number is None:
             raise NoCommitInfo()
@@ -121,7 +123,7 @@ class Imhotep(object):
                 for x in entry.added_lines:
                     pos_map[x.number] = x.position
 
-                if True:
+                if self.report_file_violations:
                     # "magic" value of line 0 represents file-level results.
                     added_lines.append(0)
 
@@ -256,6 +258,10 @@ def parse_args(args):
     arg_parser.add_argument(
         '--shallow',
         help="Performs a shallow clone of the repo",
+        action="store_true")
+    arg_parser.add_argument(
+        '--report-file-violations',
+        help="Report file-level violations, i.e. those not on individual lines",
         action="store_true")
     # parse out repo name
     return arg_parser.parse_args(args)

--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -117,9 +117,13 @@ class Imhotep(object):
             error_count = 0
             for entry in parse_results:
                 added_lines = [l.number for l in entry.added_lines]
-                pos_map = {}
+                pos_map = {0: min(l.position for l in entry.added_lines)}
                 for x in entry.added_lines:
                     pos_map[x.number] = x.position
+
+                if True:
+                    # "magic" value of line 0 represents file-level results.
+                    added_lines.append(0)
 
                 violations = results.get(entry.result_filename, {})
                 violating_lines = [int(l) for l in violations.keys()]

--- a/imhotep/app_test.py
+++ b/imhotep/app_test.py
@@ -319,8 +319,23 @@ def test_invoke__reports_file_errors():
         pr_number=1,
         repo_manager=manager,
         commit_info=mock.Mock(),
+        report_file_violations=True,
     )
     imhotep.invoke(reporter=reporter)
 
     assert reporter.report_line.called
+    assert not reporter.post_comment.called
+
+    # Reset mock and ensure that the default case is no file-level violations.
+    reporter.reset_mock()
+
+    imhotep = Imhotep(
+        pr_number=1,
+        repo_manager=manager,
+        commit_info=mock.Mock(),
+        # report_file_violations is False by default
+    )
+    imhotep.invoke(reporter=reporter)
+
+    assert not reporter.report_line.called
     assert not reporter.post_comment.called

--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -11,6 +11,9 @@ class Tool(object):
 
       {'relative_filename': {'line_number': [error1, error2]}}
       eg: {'imhotep/app.py': {'103': ['line too long']}}
+
+    Line numbers are indexed from 1, with the value 0 signifying a file-level
+    linting violation.
     """
 
     def __init__(self, command_executor, filenames=set()):


### PR DESCRIPTION
This PR adds optional reporting for linting violations at the file level, addressing issue #85.

A concrete example of this is flake8-isort, which reports a file not being “isorted” as having a violation on line 0.

This change adds the option `--report-file-violations`, which will cause the value 0 to be forcibly added to the ‘changed lines’, so that Imhotep will include violations on line 0. This behaviour is then documented in `tools.py`. Finally, the mapping of line numbers to diff positions is updated to include a mapping form 0 to the lowest value line in the diff, so that Imhotep will report file violations on the first line it can in a given file.

Comments and thoughts on implementation/documentation/etc welcomed.