### PR TITLE
Make report_line function signatures consistent across all reporters

### DIFF
--- a/imhotep/integration_test.py
+++ b/imhotep/integration_test.py
@@ -36,7 +36,7 @@ def test_github_post():
     test_str = 'integration test error name'
     req = BasicAuthRequester(ghu, ghp)
     r = PRReporter(req, repo, pr)
-    r.report_line(repo, 'da6a127a285ae08d9bfcccb1cb62aef908485769', 'foo.py', 2, 3, test_str)
+    r.report_line('da6a127a285ae08d9bfcccb1cb62aef908485769', 'foo.py', 2, 3, test_str)
     comments = req.get('https://api.github.com/repos/%s/pulls/%s/comments' %
                        (repo, pr)).json()
     posted = [x for x in comments if test_str in x['body']]

--- a/imhotep/reporters/printing.py
+++ b/imhotep/reporters/printing.py
@@ -6,8 +6,7 @@ log = logging.getLogger(__name__)
 
 
 class PrintingReporter(Reporter):
-    def report_line(self, repo_name, commit, file_name, line_number, position,
-                    message):
+    def report_line(self, commit, file_name, line_number, position, message):
         print("Would have posted the following: \n"
               "commit: %(commit)s\n"
               "position: %(position)s\n"

--- a/imhotep/reporters/reporter.py
+++ b/imhotep/reporters/reporter.py
@@ -10,6 +10,6 @@ class Reporter(object):
     be used to notify the user that lint stopped running due to a critical
     number of errors.
     """
-    def report_line(self, repo_name, commit, file_name, line_number, position,
+    def report_line(self, commit, file_name, line_number, position,
                     message):
         raise NotImplementedError()


### PR DESCRIPTION
It seems like this needs to be done? I'm currently getting this error when running with `--no-post`: 
```
Traceback (most recent call last):
  File "/mnt/services/jenkins/workspace/imhotep/imhotep/bin/imhotep", line 9, in <module>
    load_entry_point('imhotep==1.0.1', 'console_scripts', 'imhotep')()
  File "/mnt/services/jenkins/workspace/imhotep/imhotep/imhotep/main.py", line 54, in main
    imhotep.invoke()
  File "/mnt/services/jenkins/workspace/imhotep/imhotep/imhotep/app.py", line 135, in invoke
    x, pos_map[x], violations['%s' % x])
TypeError: report_line() takes exactly 7 arguments (6 given)
```

Here are the signatures before and after the changes:

![screen shot 2016-07-24 at 2 08 03 pm](https://cloud.githubusercontent.com/assets/1906805/17086485/2b60cfea-51a8-11e6-9451-fed264956fc7.png)
![screen shot 2016-07-24 at 2 07 46 pm](https://cloud.githubusercontent.com/assets/1906805/17086486/2fe99da8-51a8-11e6-9a77-e2c1ed85ec68.png)

Let me know if I misunderstood. Thanks!