### PR TITLE
Fix string interpolation in PrintingReporter

### DIFF
--- a/imhotep/reporters/printing.py
+++ b/imhotep/reporters/printing.py
@@ -1,5 +1,4 @@
 import logging
-from six import string_types
 from .reporter import Reporter
 
 log = logging.getLogger(__name__)
@@ -11,9 +10,7 @@ class PrintingReporter(Reporter):
               "commit: %(commit)s\n"
               "position: %(position)s\n"
               "message: %(message)s\n"
-              "file: %(filename)s\n"
-              "repo: %(repo)s\n" % {
-                  'repo': repo_name,
+              "file: %(filename)s\n" % {
                   'commit': commit,
                   'position': position,
                   'message': message,

--- a/imhotep/reporters/reporters_test.py
+++ b/imhotep/reporters/reporters_test.py
@@ -1,6 +1,7 @@
 import mock
 
 from imhotep.reporters.github import CommitReporter, GitHubReporter, PRReporter
+from imhotep.reporters.printing import PrintingReporter
 from imhotep.testing_utils import Requester
 
 
@@ -106,3 +107,14 @@ def test_pr__post_comment():
     pr.post_comment("my-message")
 
     assert requester.post.called
+
+
+def test_printing_reporter_report_line():
+    # smoke test to make sure the string interpolation doesn't explode
+    PrintingReporter().report_line(
+        commit='commit',
+        file_name='file.py',
+        line_number=123,
+        position=1,
+        message='message'
+    )


### PR DESCRIPTION
We no longer have `repo_name` here, so this interpolation needs fixing. This should have been a part of https://github.com/justinabrahms/imhotep/pull/88. My fault!

The test I added fails without this change. Here's the output from the test:

```
imhotep/reporters/reporters_test.py Would have posted the following: 
commit: commit
position: 1
message: message
file: file.py
```