### PR TITLE
Don't clobber errors

### DIFF
--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -44,7 +44,13 @@ def run_analysis(repo, filenames=set(), linter_configs=set()):
         run_results = tool.invoke(repo.dirname,
                                   filenames=filenames,
                                   linter_configs=linter_configs)
-        results.update(run_results)
+
+        for fname, fresults in run_results.items():
+            results.setdefault(fname, {})
+            for lineno, violations in fresults.items():
+                results[fname].setdefault(lineno, [])
+                results[fname][lineno].extend(violations)
+
     return results
 
 

--- a/imhotep/app_test.py
+++ b/imhotep/app_test.py
@@ -70,6 +70,18 @@ def test_tools_merges_tool_results():
     assert 'b' in retval
 
 
+def test_tools_merges_results_without_overwriting():
+    m = mock.MagicMock()
+    m.invoke.return_value = {'a': {'b': [1]}}
+    m2 = mock.MagicMock()
+    m2.invoke.return_value = {'a': {'b': [2]}}
+    repo = Repository('name', 'location', [m, m2], None)
+    retval = run_analysis(repo)
+
+    assert 1 in retval['a']['b']
+    assert 2 in retval['a']['b']
+
+
 def test_tools_errors_on_no_tools():
     try:
         Repository('name', 'location', [], None)

--- a/imhotep/app_test.py
+++ b/imhotep/app_test.py
@@ -51,7 +51,7 @@ def test_tools_invoked_on_repo():
 def test_run_analysis__config_fetch_error_handled():
     mock_tool = mock.Mock()
     mock_tool.get_configs.side_effect = AttributeError()
-    mock_tool.invoke.return_value = []
+    mock_tool.invoke.return_value = {}
 
     repo = Repository('name', 'loc', [mock_tool], None)
 
@@ -60,9 +60,9 @@ def test_run_analysis__config_fetch_error_handled():
 
 def test_tools_merges_tool_results():
     m = mock.MagicMock()
-    m.invoke.return_value = {'a': 1}
+    m.invoke.return_value = {'a': {}}
     m2 = mock.MagicMock()
-    m2.invoke.return_value = {'b': 2}
+    m2.invoke.return_value = {'b': {}}
     repo = Repository('name', 'location', [m, m2], None)
     retval = run_analysis(repo)
 


### PR DESCRIPTION
Say I lint the following file:

```python
requests.get('https://python.org', verify=False)
```

...with Bandit and Flake8. Bandit will run and return:

```json
{"file.py": {"1": ["something about SSL"]}}
```

...and then Flake8 will run and return:

```json
{"file.py": {"1": ["Module requests not found"]}}
```

These results will get `dict.merge`'d together, therefore clobbering the Bandit result with the Flake8 result, as it's a shallow merge.

This change fixes that issue by deep merging the results. Since that requires that the API is conformed to, I've updated tests so that they return valid data.

Side note – can we have a new PyPI release? I noticed that none of the recent changes are on PyPI (including the printing reporter being broken).