### PR TITLE
Fix file extension filtering

### DIFF
--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -40,7 +40,7 @@ class Tool(object):
         """
         retval = defaultdict(lambda: defaultdict(list))
         if len(filenames):
-            extensions = self.get_file_extensions()
+            extensions = [e[1:] for e in self.get_file_extensions()]
             filenames = [f for f in filenames if f.split('.')[-1] in extensions]
 
             if not filenames:

--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -40,6 +40,8 @@ class Tool(object):
         """
         retval = defaultdict(lambda: defaultdict(list))
         if len(filenames):
+            extensions = self.get_file_extensions()
+            filenames = [f for f in filenames if f.split('.')[-1] in extensions]
             to_find = ' -o '.join(['-samefile "%s"' % f for f in filenames])
         else:
             to_find = ' -o '.join(['-name "*%s"' % ext

--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -40,7 +40,7 @@ class Tool(object):
         """
         retval = defaultdict(lambda: defaultdict(list))
         if len(filenames):
-            extensions = [e[1:] for e in self.get_file_extensions()]
+            extensions = [e.lstrip('.') for e in self.get_file_extensions()]
             filenames = [f for f in filenames if f.split('.')[-1] in extensions]
 
             if not filenames:

--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -42,6 +42,12 @@ class Tool(object):
         if len(filenames):
             extensions = self.get_file_extensions()
             filenames = [f for f in filenames if f.split('.')[-1] in extensions]
+
+            if not filenames:
+                # There were a specified set of files, but none were the right
+                # extension. Different from the else-case below.
+                return {}
+
             to_find = ' -o '.join(['-samefile "%s"' % f for f in filenames])
         else:
             to_find = ' -o '.join(['-name "*%s"' % ext

--- a/imhotep/tools_test.py
+++ b/imhotep/tools_test.py
@@ -118,3 +118,21 @@ def test_process_line_no_response_format():
     t = Tool(command_executor='')
     with pytest.raises(NotImplementedError):
         t.process_line(dirname='/my/full/path', line='my line')
+
+
+def test_invoke_finds_named_files():
+    m = mock.Mock()
+    m.return_value = ""
+    t = ExampleTool(m)
+    t.invoke('/woobie/', filenames=['foo.exe'])
+
+    assert len(calls_matching_re(
+        m, re.compile(r'-samefile "foo\.exe"'))) > 0
+
+def test_invoke_bails_out_fast_if_no_filename_matches():
+    m = mock.Mock()
+    m.return_value = ""
+    t = ExampleTool(m)
+    t.invoke('/woobie/', filenames=['foo.py'])
+
+    assert not m.called


### PR DESCRIPTION
This fixes the default behaviour of file extension filtering, therefore fixing an issue with `imhotep_eslint` and possibly other plugins.

When a file list is provided, the applicable file extension list provided by a plugin is not honoured.

I'm not sure if the existing behaviour is the _desired_ behaviour, it certainly could be argued that it is, but it was not how I interpreted the API, and it has caused issues with ESLint reporting Python files as being "invalid", just because they don't parse as Javascript. I'm happy to discuss the issue around the correct behaviour further, or for this to just be merged with a version bump.