### PR TITLE
Skip empty files

### DIFF
--- a/imhotep/app.py
+++ b/imhotep/app.py
@@ -124,6 +124,8 @@ class Imhotep(object):
             error_count = 0
             for entry in parse_results:
                 added_lines = [l.number for l in entry.added_lines]
+                if not entry.added_lines:
+                    continue
                 pos_map = {0: min(l.position for l in entry.added_lines)}
                 for x in entry.added_lines:
                     pos_map[x.number] = x.position

--- a/imhotep/fixtures/deleted_file.diff
+++ b/imhotep/fixtures/deleted_file.diff
@@ -1,0 +1,5 @@
+diff --git a/setup.cfg b/setup.cfg
+deleted file mode 100644
+index 7c1de86..0000000
+--- a/setup.cfg
++++ /dev/null


### PR DESCRIPTION
This fixes a crash when analysing files with no added lines.