### PR TITLE
Make sure we can always find the right file

### DIFF
--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -53,8 +53,8 @@ class Tool(object):
             to_find = ' -o '.join(['-name "*%s"' % ext
                                    for ext in self.get_file_extensions()])
 
-        cmd = 'find %s %s | xargs %s' % (
-            dirname, to_find, self.get_command(
+        cmd = 'cd %s; find %s %s | xargs %s' % (
+            dirname, dirname, to_find, self.get_command(
                 dirname,
                 linter_configs=linter_configs))
         result = self.executor(cmd)

--- a/imhotep/tools.py
+++ b/imhotep/tools.py
@@ -53,8 +53,8 @@ class Tool(object):
             to_find = ' -o '.join(['-name "*%s"' % ext
                                    for ext in self.get_file_extensions()])
 
-        cmd = 'cd %s; find %s %s | xargs %s' % (
-            dirname, dirname, to_find, self.get_command(
+        cmd = 'find %s -path "*/%s" | xargs %s' % (
+            dirname, to_find, self.get_command(
                 dirname,
                 linter_configs=linter_configs))
         result = self.executor(cmd)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='imhotep',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(),
     url='https://github.com/justinabrahms/imhotep',
     license='MIT',


### PR DESCRIPTION
Looks like there was an edge case in how find was finding particular files. This fixes it.

Would appreciate review from @justinabrahms in case you can think of any knock-on issues this might cause.